### PR TITLE
Containerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,65 @@
+# Version control
+.git
+.gitignore
+.github
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+venv/
+ENV/
+env/
+.venv/
+.env/
+
+# IDE files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Docker files
+Dockerfile
+.dockerignore
+
+# Documentation
+docs/
+*.md
+LICENSE
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+
+# Log files
+*.log
+logs/
+
+# Local configuration
+.env
+.env.local
+config.local.yaml

--- a/.github/workflows/dev-push.yaml
+++ b/.github/workflows/dev-push.yaml
@@ -1,0 +1,42 @@
+name: Dev Branch
+
+on:
+  push:
+    branches: [ "dev" ]
+    paths:
+      - 'hecstac/**'
+      - 'Dockerfile'
+      - '.dockerignore'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          
+      - name: Extract version from hecstac
+        id: get_version
+        shell: pwsh
+        run: |
+          $version = python -c "import hecstac; print(hecstac.__version__);"
+          echo "VERSION=$version" >> $env:GITHUB_OUTPUT
+
+  docker-build-push:
+    needs: get-version
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      push_to_registry: true
+      version: ${{ needs.get-version.outputs.version }}
+      branch: 'dev'
+      platforms: 'linux/amd64,linux/arm64'

--- a/.github/workflows/dev-push.yaml
+++ b/.github/workflows/dev-push.yaml
@@ -34,7 +34,7 @@ jobs:
 
   docker-build-push:
     needs: get-version
-    uses: ./.github/workflows/docker-build.yml
+    uses: ./.github/workflows/docker-build.yaml
     with:
       push_to_registry: true
       version: ${{ needs.get-version.outputs.version }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,65 @@
+name: Docker Build
+
+on:
+  workflow_call:
+    inputs:
+      push_to_registry:
+        type: boolean
+        default: false
+        required: false
+      version:
+        type: string
+        required: true
+      branch:
+        type: string
+        required: true
+      platforms:
+        type: string
+        default: 'linux/amd64,linux/arm64'
+        required: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set Docker tags based on branch
+        id: set_tags
+        run: |
+          if [[ "${{ inputs.branch }}" == "main" ]]; then
+            echo "TAGS=ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${{ inputs.version }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ inputs.branch }}" == "dev" ]]; then
+            echo "TAGS=ghcr.io/${{ github.repository }}:${{ inputs.version }}-dev" >> $GITHUB_OUTPUT
+          else
+            echo "TAGS=ghcr.io/${{ github.repository }}:pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: inputs.push_to_registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ inputs.platforms }}
+          push: ${{ inputs.push_to_registry }}
+          tags: ${{ steps.set_tags.outputs.TAGS }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -1,0 +1,42 @@
+name: Main Branch
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'hecstac/**'
+      - 'Dockerfile'
+      - '.dockerignore'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          
+      - name: Extract version from hecstac
+        id: get_version
+        shell: pwsh
+        run: |
+          $version = python -c "import hecstac; print(hecstac.__version__);"
+          echo "VERSION=$version" >> $env:GITHUB_OUTPUT
+
+  docker-build-push:
+    needs: get-version
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      push_to_registry: true
+      version: ${{ needs.get-version.outputs.version }}
+      branch: 'main'
+      platforms: 'linux/amd64,linux/arm64'

--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -34,7 +34,7 @@ jobs:
 
   docker-build-push:
     needs: get-version
-    uses: ./.github/workflows/docker-build.yml
+    uses: ./.github/workflows/docker-build.yaml
     with:
       push_to_registry: true
       version: ${{ needs.get-version.outputs.version }}

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -34,7 +34,7 @@ jobs:
 
   docker-build-test:
     needs: get-version
-    uses: ./.github/workflows/docker-build.yml
+    uses: ./.github/workflows/docker-build.yaml
     with:
       push_to_registry: false
       version: ${{ needs.get-version.outputs.version }}

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,0 +1,42 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: [ "main", "dev" ]
+    paths:
+      - 'hecstac/**'
+      - 'Dockerfile'
+      - '.dockerignore'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          
+      - name: Extract version from hecstac
+        id: get_version
+        shell: pwsh
+        run: |
+          $version = python -c "import hecstac; print(hecstac.__version__);"
+          echo "VERSION=$version" >> $env:GITHUB_OUTPUT
+
+  docker-build-test:
+    needs: get-version
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      push_to_registry: false
+      version: ${{ needs.get-version.outputs.version }}
+      branch: ${{ github.base_ref }}
+      platforms: 'linux/amd64'  # Only build for one platform to save time on PRs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.12-slim
+
+# Set working directory
+WORKDIR /app
+
+# Install git and build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    build-essential \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Clone rasqc (feature/stac-checker branch)
+RUN git clone https://github.com/fema-ffrd/rasqc.git && \
+    cd rasqc/ && \
+    git checkout feature/stac-checker
+
+# Install build tools
+RUN pip install --no-cache-dir build
+
+# Build and install rasqc
+RUN cd /app/rasqc/ && \
+    python -m build && \
+    pip install --no-cache-dir dist/rasqc-0.0.1rc1-py3-none-any.whl
+
+# Build and install hecstac
+COPY . /app/hecstac/
+RUN cd /app/hecstac/ && \
+    python -m build && \
+    pip install --no-cache-dir dist/hecstac-0.1.0rc3-py3-none-any.whl
+
+# Default command (todo: change to entrypoint script)
+CMD ["python"]


### PR DESCRIPTION
This PR adds Docker image building and publishing capabilities to the project.

## Changes

1. **Added Docker support**:
   - Created a Dockerfile that builds a Python 3.12 environment and installs the rasqc and hecstac packages from source
   - Added a .dockerignore file to reduce build context and improve build times

2. **New CI/CD workflows**:
   - `docker-build.yml`: Reusable workflow component for building Docker images
   - `pr-checks.yml`: Tests Docker builds on PRs without publishing
   - `main-push.yml`: Builds and publishes Docker images for main branch
   - `dev-push.yml`: Builds and publishes Docker images for dev branch

3. **Tagging strategy**:
   - **Dev branch**: Images tagged with version-dev (e.g., "1.0.0-dev")
   - **Main branch**: Images tagged with both version (e.g., "1.0.0") and "latest"

## Publishing

The Docker images are published to GitHub Container Registry (ghcr.io) using the repository name. This works in parallel with our existing GitHub Release process for Python packages.

All published images are built for both x86 (amd64) and ARM (arm64) architectures.

## TODO

- Add an entrypoint script to the Docker image once it is completed