### PR TITLE
Containerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,7 +9,6 @@ __pycache__/
 *$py.class
 *.so
 .Python
-env/
 build/
 develop-eggs/
 dist/
@@ -21,9 +20,127 @@ lib64/
 parts/
 sdist/
 var/
+wheels/
+share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+# .python-version
+
+# pipenv
+#Pipfile.lock
+
+# poetry
+#poetry.lock
+
+# pdm
+.pdm.toml
+.pdm-python
+.pdm-build/
+#pdm.lock
+
+# PEP 582
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#.idea/
 
 # Virtual environments
 venv/
@@ -63,3 +180,8 @@ logs/
 .env
 .env.local
 config.local.yaml
+
+# Project specific
+ElkMiddle
+Muncie
+data/

--- a/.github/workflows/dev-push.yaml
+++ b/.github/workflows/dev-push.yaml
@@ -39,4 +39,4 @@ jobs:
       push_to_registry: true
       version: ${{ needs.get-version.outputs.version }}
       branch: 'dev'
-      platforms: 'linux/amd64,linux/arm64'
+      platforms: 'linux/amd64'

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -15,7 +15,7 @@ on:
         required: true
       platforms:
         type: string
-        default: 'linux/amd64,linux/arm64'
+        default: 'linux/amd64'
         required: false
 
 permissions:

--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -39,4 +39,4 @@ jobs:
       push_to_registry: true
       version: ${{ needs.get-version.outputs.version }}
       branch: 'main'
-      platforms: 'linux/amd64,linux/arm64'
+      platforms: 'linux/amd64'

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -39,4 +39,4 @@ jobs:
       push_to_registry: false
       version: ${{ needs.get-version.outputs.version }}
       branch: ${{ github.base_ref }}
-      platforms: 'linux/amd64,linux/arm64'
+      platforms: 'linux/amd64'

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -39,4 +39,4 @@ jobs:
       push_to_registry: false
       version: ${{ needs.get-version.outputs.version }}
       branch: ${{ github.base_ref }}
-      platforms: 'linux/amd64'  # Only build for one platform to save time on PRs
+      platforms: 'linux/amd64,linux/arm64'

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN cd /app/rasqc/ && \
 COPY . /app/hecstac/
 RUN cd /app/hecstac/ && \
     python -m build && \
-    pip install --no-cache-dir dist/hecstac-0.1.0rc3-py3-none-any.whl
+    pip install --no-cache-dir dist/hecstac-*-py3-none-any.whl
 
 # Default command (todo: change to entrypoint script)
 CMD ["python"]


### PR DESCRIPTION
This pull request includes updates to the `.dockerignore` file to exclude additional files and directories from the project .gitignore, a change to the workflows to remove multi platform builds, and a modification to the `Dockerfile` to simplify the installation of the `hecstac` package. Below is a summary of the changes:

### Updates to `.dockerignore`:

* Added exclusions for various Python-related files and directories, such as `*.pyc`, `.tox/`, `.pytest_cache/`, `.ipynb_checkpoints`, and `.venv/`, among others. This ensures these files are not included in Docker builds.
* Added project-specific exclusions, such as `data/`, `ElkMiddle`, and `Muncie`, to prevent unnecessary files from being included in the Docker context.

### Workflow improvement:

* Updated workflows to build docker image only for the `linux/amd64`platform due to dependency issue with ARM.

### Dockerfile changes:

* Modified the `Dockerfile` to use a wildcard (`hecstac-*-py3-none-any.whl`) when installing the `hecstac` package, making the build process more flexible and avoiding hardcoding the version.