### PR TITLE
fix: add installation of build dependencies in GitHub release workflow

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -23,6 +23,11 @@ jobs:
         with:
           python-version: '3.10'
           
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+          
       - name: Build wheel and source distribution
         run: python -m build
         


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to ensure build dependencies are installed before creating distributions.

Enhancements to the GitHub Actions workflow:

* [`.github/workflows/github-release.yaml`](diffhunk://#diff-8a853bce863ed6c4e138b0527f8f1ae72a4c56908c996963cf8afed0cf5764f7R26-R30): Added a step to install and upgrade pip, as well as to install the `build` package.