### PR TITLE
Refactor item properties

### DIFF
--- a/hecstac/common/asset_factory.py
+++ b/hecstac/common/asset_factory.py
@@ -56,7 +56,7 @@ class GenericAsset(Asset, Generic[T]):
         self._extra_fields = extra_fields
 
     @property
-    def file(self):
+    def file(self) -> T:
         """Return cached file or instantiate new."""
         if not hasattr(self, "_file_obj"):
             if self.__file_class__:

--- a/hecstac/ras/item.py
+++ b/hecstac/ras/item.py
@@ -2,7 +2,7 @@
 
 import datetime
 import json
-from functools import cached_property, lru_cache
+from functools import cached_property
 from pathlib import Path
 
 import pystac
@@ -13,14 +13,18 @@ from pystac.extensions.projection import ProjectionExtension
 from pystac.utils import datetime_to_str
 from shapely import Polygon, simplify, to_geojson, union_all
 from shapely.geometry import shape
-from hecstac.common.base_io import ModelFileReaderError
+
+import hecstac
 from hecstac.common.asset_factory import AssetFactory
+from hecstac.common.base_io import ModelFileReaderError
 from hecstac.common.logger import get_logger
 from hecstac.common.path_manager import LocalPathManager
-from hecstac.ras.assets import RAS_EXTENSION_MAPPING, GeometryAsset, GeometryHdfAsset
+from hecstac.ras.assets import RAS_EXTENSION_MAPPING, GeometryAsset, GeometryHdfAsset, ProjectAsset
 from hecstac.ras.consts import NULL_DATETIME, NULL_STAC_BBOX, NULL_STAC_GEOMETRY
 from hecstac.ras.parser import ProjectFile
 from hecstac.ras.utils import find_model_files
+
+logger = get_logger(__name__)
 
 
 class RASModelItem(Item):
@@ -29,26 +33,22 @@ class RASModelItem(Item):
     PROJECT = "HEC-RAS:project"
     PROJECT_TITLE = "HEC-RAS:project_title"
     MODEL_UNITS = "HEC-RAS:unit system"
-    MODEL_GAGES = "HEC-RAS:gages"
+    MODEL_GAGES = "HEC-RAS:gages"  # TODO: Is this deprecated?
     PROJECT_VERSION = "HEC-RAS:version"
     PROJECT_DESCRIPTION = "HEC-RAS:description"
     PROJECT_STATUS = "HEC-RAS:status"
-    PROJECT_UNITS = "HEC-RAS:unit_system"
-
     RAS_HAS_1D = "HEC-RAS:has_1d"
     RAS_HAS_2D = "HEC-RAS:has_2d"
     RAS_DATETIME_SOURCE = "HEC-RAS:datetime_source"
+    HECSTAC_VERSION = "HEC-RAS:hecstac_version"
 
     def __init__(self, *args, **kwargs):
         """Add a few default properties to the base class."""
         super().__init__(*args, **kwargs)
         self.simplify_geometry = True
-        self.logger = get_logger(__name__)
 
     @classmethod
-    def from_prj(
-        cls, ras_project_file, item_id: str, crs: str = None, simplify_geometry: bool = True, assets: list = None
-    ):
+    def from_prj(cls, ras_project_file: str, crs: str = None, simplify_geometry: bool = True, assets: list = None):
         """
         Create a STAC item from a HEC-RAS .prj file.
 
@@ -56,8 +56,6 @@ class RASModelItem(Item):
         ----------
         ras_project_file : str
             Path to the HEC-RAS project file (.prj).
-        item_id : str
-            Unique item id for the STAC item.
         crs : str, optional
             Coordinate reference system (CRS) to apply to the item. If None, the CRS will be extracted from the geometry .hdf file.
         simplify_geometry : bool, optional
@@ -68,47 +66,45 @@ class RASModelItem(Item):
         stac : RASModelItem
             An instance of the class representing the STAC item.
         """
-        pm = LocalPathManager(Path(ras_project_file).parent)
-
-        # href = pm.item_path(item_id)
         if not assets:
-            href = pm.item_path(item_id)
             assets = {Path(i).name: Asset(i, Path(i).name) for i in find_model_files(ras_project_file)}
         else:
-            href = ras_project_file.replace(".prj", ".json")
             assets = {Path(i).name: Asset(i, Path(i).name) for i in assets}
         stac = cls(
             Path(ras_project_file).stem,
             NULL_STAC_GEOMETRY,
             NULL_STAC_BBOX,
             NULL_DATETIME,
-            {"project_file_name": Path(ras_project_file).name},
-            href=href,
+            {cls.PROJECT: Path(ras_project_file).name},
+            href=ras_project_file.replace(".prj", ".json"),
             assets=assets,
         )
         if crs:
             stac.crs = crs
         stac.simplify_geometry = simplify_geometry
-        stac.pm = pm
+        stac.update_properties()
 
         return stac
 
-    @property
-    def ras_project_file(self) -> str:
-        """Get the path to the HEC-RAS .prj file."""
-        return self._properties.get("ras_project_file")
-
-    @property
-    @lru_cache
+    @cached_property
     def factory(self) -> AssetFactory:
         """Return AssetFactory for this item."""
         return AssetFactory(RAS_EXTENSION_MAPPING)
 
     @property
-    @lru_cache
+    def pm(self) -> LocalPathManager:
+        """Get the path manager rooted at project file's href."""
+        return LocalPathManager(str(Path(self.project_asset.href).parent))
+
+    @cached_property
+    def project_asset(self) -> ProjectAsset:
+        """Find the project file for this model."""
+        return [i for i in self.assets.values() if isinstance(i, ProjectAsset)][0]
+
+    @cached_property
     def pf(self) -> ProjectFile:
         """Get a ProjectFile instance for the RAS Model .prj file."""
-        return ProjectFile(self.ras_project_file)
+        return self.project_asset.file
 
     @cached_property
     def has_2d(self) -> bool:
@@ -147,23 +143,23 @@ class RASModelItem(Item):
             return self._geometry_cached
 
         if self.crs is None:
-            self.logger.warning("Geometry requested for model with no spatial reference.")
+            logger.warning("Geometry requested for model with no spatial reference.")
             self._geometry_cached = NULL_STAC_GEOMETRY
             return self._geometry_cached
 
         hdf_geom_assets = [asset for asset in self.geometry_assets if isinstance(asset, GeometryHdfAsset)]
         if len(hdf_geom_assets) == 0:
-            self.logger.error("No geometry found for RAS item.")
+            logger.error("No geometry found for RAS item.")
             self._geometry_cached = NULL_STAC_GEOMETRY
             return self._geometry_cached
 
         geometries = []
         for i in hdf_geom_assets:
-            self.logger.debug(f"Processing geometry from {i.href}")
+            logger.debug(f"Processing geometry from {i.href}")
             try:
                 geometries.append(i.geometry_wgs84)
             except Exception as e:
-                self.logger.error(e)
+                logger.error(e)
                 continue
 
         unioned_geometry = union_all(geometries)
@@ -176,10 +172,20 @@ class RASModelItem(Item):
         self._geometry_cached = json.loads(to_geojson(unioned_geometry))
         return self._geometry_cached
 
+    @geometry.setter
+    def geometry(self, val):
+        """Ignore external setting of geometry."""
+        pass
+
     @property
     def bbox(self) -> list[float]:
         """Get the bounding box of the model geometry."""
-        return shape(self.geometry).bounds
+        return list(shape(self.geometry).bounds)
+
+    @bbox.setter
+    def bbox(self, val):
+        """Ignore external setting of bbox."""
+        pass
 
     def to_dict(self, *args, lightweight=True, **kwargs):
         """Preload fields before serializing to dict.
@@ -193,47 +199,35 @@ class RASModelItem(Item):
         _ = self.properties
         return super().to_dict(*args, **kwargs)
 
-    @property
-    def properties(self) -> dict:
-        """Properties for the RAS STAC item."""
-        if hasattr(self, "_properties_cached"):
-            return self._properties_cached
+    def update_properties(self) -> dict:
+        """Force recalculation of HEC-RAS properties."""
+        self.properties[self.PROJECT] = self.project_asset.name
+        self.properties[self.RAS_HAS_1D] = self.has_1d
+        self.properties[self.RAS_HAS_2D] = self.has_2d
+        self.properties[self.PROJECT_TITLE] = self.pf.project_title
+        self.properties[self.PROJECT_VERSION] = self.pf.ras_version
+        self.properties[self.PROJECT_DESCRIPTION] = self.pf.project_description
+        self.properties[self.PROJECT_STATUS] = self.pf.project_status
+        self.properties[self.MODEL_UNITS] = self.pf.project_units
+        self.properties[self.HECSTAC_VERSION] = hecstac.__version__
 
-        if self.ras_project_file is None:
-            self._properties_cached = self._properties
-            return self._properties_cached
-
-        properties = dict(self._properties)  # Make a copy to avoid side effects
-
-        properties[self.RAS_HAS_1D] = self.has_1d
-        properties[self.RAS_HAS_2D] = self.has_2d
-        properties[self.PROJECT_TITLE] = self.pf.project_title
-        properties[self.PROJECT_VERSION] = self.pf.ras_version
-        properties[self.PROJECT_DESCRIPTION] = self.pf.project_description
-        properties[self.PROJECT_STATUS] = self.pf.project_status
-        properties[self.MODEL_UNITS] = self.pf.project_units
-
-        if self.datetime is not None:
-            properties["datetime"] = datetime_to_str(self.datetime)
+        datetimes = self.model_datetime
+        if len(datetimes) > 1:
+            self.properties["start_datetime"] = datetime_to_str(min(datetimes))
+            self.properties["end_datetime"] = datetime_to_str(max(datetimes))
+            self.properties[self.RAS_DATETIME_SOURCE] = "model_geometry"
+            self.datetime = None
+        elif len(datetimes) == 1:
+            self.datetime = datetimes[0]
+            self.properties[self.RAS_DATETIME_SOURCE] = "model_geometry"
         else:
-            properties["datetime"] = None
-
-        self._properties_cached = properties
-        return self._properties_cached
-
-    @properties.setter
-    def properties(self, value):
-        """Manually setting properties clears the cache."""
-        self._properties = value
-        if hasattr(self, "_properties_cached"):
-            del self._properties_cached
+            logger.warning(f"Could not extract item datetime from geometry.")
+            self.datetime = datetime.datetime.now()
+            self.properties[self.RAS_DATETIME_SOURCE] = "processing_time"
 
     @property
-    def datetime(self) -> datetime.datetime | None:
+    def model_datetime(self) -> list[datetime.datetime]:
         """Parse datetime from model geometry and return result."""
-        if hasattr(self, "_datetime_cached"):
-            return self._datetime_cached
-
         datetimes = []
         for i in self.geometry_assets:
             dt = i.file.geometry_time
@@ -244,27 +238,7 @@ class RASModelItem(Item):
             elif isinstance(dt, datetime.datetime):
                 datetimes.append(dt)
 
-        datetimes = list(set(datetimes))
-        if len(datetimes) > 1:
-            self._properties["start_datetime"] = datetime_to_str(min(datetimes))
-            self._properties["end_datetime"] = datetime_to_str(max(datetimes))
-            self._properties[self.RAS_DATETIME_SOURCE] = "model_geometry"
-            item_time = None
-        elif len(datetimes) == 1:
-            item_time = datetimes[0]
-            self._properties[self.RAS_DATETIME_SOURCE] = "model_geometry"
-        else:
-            self.logger.warning(f"Could not extract item datetime from geometry.")
-            item_time = datetime.datetime.now()
-            self._properties[self.RAS_DATETIME_SOURCE] = "processing_time"
-
-        self._datetime_cached = item_time
-        return item_time
-
-    @datetime.setter
-    def datetime(self, value):
-        """Ignore external setting of datetime."""
-        pass
+        return list(set(datetimes))
 
     def add_model_thumbnails(
         self, layers: list, title_prefix: str = "Model_Thumbnail", thumbnail_dir=None, s3_thumbnail_dst=None
@@ -286,12 +260,12 @@ class RASModelItem(Item):
             thumbnail_dest = s3_thumbnail_dst
 
         else:
-            self.logger.warning(f"No thumbnail directory provided.  Using item directory {self.self_href}")
+            logger.warning(f"No thumbnail directory provided.  Using item directory {self.self_href}")
             thumbnail_dest = self.self_href
 
         for geom in self.geometry_assets:
             if isinstance(geom, GeometryHdfAsset) and geom.has_2d:
-                self.logger.info(f"Writing: {thumbnail_dest}")
+                logger.info(f"Writing: {thumbnail_dest}")
                 self.assets[f"{geom.href.rsplit('/')[-1]}_thumbnail"] = geom.thumbnail(
                     layers=layers, title=title_prefix, thumbnail_dest=thumbnail_dest
                 )
@@ -300,7 +274,6 @@ class RASModelItem(Item):
 
     def add_asset(self, key, asset):
         """Subclass asset then add, eagerly load metadata safely."""
-        logger = get_logger(__name__)
         subclass = self.factory.asset_from_dict(asset)
         if subclass is None:
             return
@@ -320,18 +293,3 @@ class RASModelItem(Item):
             self.crs = subclass.file.projection
 
         return super().add_asset(key, subclass)
-
-    @geometry.setter
-    def geometry(self, *args, **kwargs):
-        """Ignore."""
-        pass
-
-    @bbox.setter
-    def bbox(self, *args, **kwargs):
-        """Ignore."""
-        pass
-
-    @datetime.setter
-    def datetime(self, *args, **kwargs):
-        """Ignore."""
-        pass

--- a/tests/unit/ras_test.py
+++ b/tests/unit/ras_test.py
@@ -1,0 +1,83 @@
+import json
+import logging
+from ast import mod
+from pathlib import Path
+from pyexpat import model
+
+import pytest
+
+from hecstac.common.logger import initialize_logger
+from hecstac.ras.item import RASModelItem
+
+initialize_logger(level=logging.CRITICAL)
+
+DATA_DIR = Path(__file__).parent.parent / "test_data" / "input" / "ras_test"
+OUTPUT_DIR = Path(__file__).parent.parent / "test_data" / "output" / "ras_test"
+DATA_DIR.mkdir(exist_ok=True, parents=True)
+OUTPUT_DIR.mkdir(exist_ok=True, parents=True)
+
+
+def ras_models():
+    directory = DATA_DIR / "metadata.json"
+    with open(directory) as f:
+        models = json.load(f)
+    models = [i for i in models if i["directory"] == "0ad5b6c4252c9a1bcf261674527e289fa751eafd981d444c5680fe200fe5e2e3"]
+    for m in models:
+        prj_path = DATA_DIR / m["directory"] / m["prj_file"]
+        yield (str(prj_path), m["crs"])
+
+
+@pytest.mark.parametrize("prj_path, crs", ras_models())
+def test_stac_creation(prj_path: str, crs: str):
+    """Test STAC item creation and serialization/deserialization."""
+    item = RASModelItem.from_prj(prj_path, crs)
+
+    # In-memory check
+    dict_1 = item.to_dict()
+    dict_2 = RASModelItem.from_dict(dict_1).to_dict()
+    if dict_1 != dict_2:
+        bad_fields = dict_comparer(dict_1, dict_2)
+        if bad_fields != ["datetime"]:  # allow only dt diffs
+            raise RuntimeError(f"Serialization failed for {prj_path}. The following fields do not match: {bad_fields}")
+
+    # To file check
+    out_dir = Path(prj_path.replace(str(DATA_DIR), str(OUTPUT_DIR))).parent.mkdir(exist_ok=True, parents=True)
+    out_path = str(out_dir).replace(".prj", ".json")
+    with open(out_path, "w") as f:
+        json.dump(dict_1, f, indent=4)
+    with open(out_path) as f:
+        dict_2 = json.load(f)
+    if dict_1 != dict_2:
+        bad_fields = dict_comparer(dict_1, dict_2)
+        if bad_fields != ["datetime"]:  # allow only dt diffs
+            raise RuntimeError(f"Serialization failed for {prj_path}. The following fields do not match: {bad_fields}")
+    print(f"{prj_path} passed")
+
+
+def dict_comparer(dict_1, dict_2, tb=""):
+    bad_fields = []
+    for i in dict_1:
+        if isinstance(dict_1[i], dict):
+            if not isinstance(dict_2[i], dict):
+                print_mismatch(i, dict_1, dict_2, tb)
+            else:
+                tmp_fields = dict_comparer(dict_1[i], dict_2[i], f"{tb}-{i}")
+                bad_fields.extend(tmp_fields)
+        elif not dict_1[i] == dict_2[i]:
+            print_mismatch(i, dict_1, dict_2, f"{tb}-{i}")
+            bad_fields.append(i)
+    return bad_fields
+
+
+def print_mismatch(i, dict_1, dict_2, tb):
+    print(f"mismatch in {tb}")
+    print(dict_1[i])
+    print()
+    print(dict_2[i])
+    print("=" * 50)
+
+
+if __name__ == "__main__":
+    for m in ras_models():
+        test_stac_creation(*m)
+        # test_project_file_access(*m)


### PR DESCRIPTION
This PR drastically simplifies the HEC-RAS item properties method and updates several miscellaneous issues encountered during the refactor.

Issue #54 demonstrated how all custom hecstac properties for HEC-RAS items were never generated/reported. This refactor moves the generation of all hecstac properties inside the from_prj constructor.  This has several implications

1. Properties will not dynamically update.  Ex. An item is written to json, the model is updated, and the item is reloaded into python memory.  In this example, the newly-loaded RasModelItem will still have the properties from the time of creation with the from_prj method.
2. There were many instances of circular references to the properties method (especially during item initialization).  By avoiding overwriting the properties method of pystac.Item, this is avoided.  Extensions such as the projection extension now function better as well.
3. Users can call the update_properties method to update properties to reflect the model state at asset load time.
4. the datetime property of pystac.Item is no longer overwritten.  This should reduce conflicts between pystac default behavior.

Additional fixes

1. type hinting for asset files has been corrected.
2. a new property hecstac_version has been added to track metadata versions.
3. the logger initialization has been moved to .py file initialization instead of item initialization.  I believe this is better practice.
4. Some simple serialize/deserialize tests have been added to make sure that identical stac items can be generated after writing to json/dict.

closes #54 