### PR TITLE
Docker scout pr fix

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -30,21 +30,26 @@ jobs:
   build-docker:
     runs-on: ubuntu-latest
     outputs:
-      image_tag: ${{ steps.set_tags.outputs.TAGS }}
+      image_tag: ${{ steps.meta.outputs.tags }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set Docker tags based on branch
-        id: set_tags
-        run: |
-          if [[ "${{ inputs.branch }}" == "main" ]]; then
-            echo "TAGS=ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${{ inputs.version }}" >> $GITHUB_OUTPUT
-          elif [[ "${{ inputs.branch }}" == "dev" ]]; then
-            echo "TAGS=ghcr.io/${{ github.repository }}:${{ inputs.version }}-dev" >> $GITHUB_OUTPUT
-          else
-            echo "TAGS=ghcr.io/${{ github.repository }}:pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          fi
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # tag events
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            # branch events - dev branch gets dev tag
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+            # main branch gets latest tag
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            # PR builds get a unique tag based on PR number and commit
+            type=ref,event=pr
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -66,6 +71,7 @@ jobs:
           context: .
           platforms: ${{ inputs.platforms }}
           push: ${{ inputs.push_to_registry }}
-          tags: ${{ steps.set_tags.outputs.TAGS }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -17,6 +17,10 @@ on:
         type: string
         default: 'linux/amd64'
         required: false
+    outputs:
+      image_tag:
+        description: 'Docker image tags'
+        value: ${{ jobs.build-docker.outputs.image_tag }}
 
 permissions:
   contents: read
@@ -65,14 +69,3 @@ jobs:
           tags: ${{ steps.set_tags.outputs.TAGS }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  docker-scout:
-    needs: build-docker
-    if: always()
-    permissions:
-      contents: read
-      pull-requests: write
-    uses: ./.github/workflows/docker-scout.yaml
-    with:
-      image_tag: ${{ needs.build-docker.outputs.image_tag || 'ghcr.io/fema-ffrd/hecstac:latest' }}
-    secrets: inherit

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -26,6 +26,10 @@ permissions:
   contents: read
   packages: write
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build-docker:
     runs-on: ubuntu-latest
@@ -61,7 +65,7 @@ jobs:
         if: inputs.push_to_registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/scout-action@v1
         with:
           command: cves
-          image: ghcr.io/fema-ffrd/hecstac:latest
+          image: ${{ inputs.image_tag || 'ghcr.io/fema-ffrd/stormlit:latest' }}
           only-severities: critical,high
           summary: true
           exit-code: true

--- a/.github/workflows/docker-scout.yaml
+++ b/.github/workflows/docker-scout.yaml
@@ -39,3 +39,4 @@ jobs:
           image: ghcr.io/fema-ffrd/hecstac:latest
           only-severities: critical,high
           summary: true
+          exit-code: true

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -40,8 +40,18 @@ jobs:
     needs: get-version
     uses: ./.github/workflows/docker-build.yaml
     with:
-      push_to_registry: false
+      push_to_registry: true
       version: ${{ needs.get-version.outputs.version }}
       branch: ${{ github.base_ref }}
       platforms: 'linux/amd64'
+    secrets: inherit
+
+  docker-scout:
+    needs: docker-build-test
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ./.github/workflows/docker-scout.yaml
+    with:
+      image_tag: ${{ needs.docker-build-test.outputs.image_tag }}
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Dev CI](https://github.com/fema-ffrd/hecstac/actions/workflows/dev-push.yaml/badge.svg?branch=dev)](https://github.com/fema-ffrd/hecstac/actions/workflows/dev-push.yaml)
 [![Documentation Status](https://readthedocs.org/projects/hecstac/badge/?version=latest)](https://hecstac.readthedocs.io/en/latest/?badge=latest)
 [![PyPI version](https://badge.fury.io/py/hecstac.svg)](https://badge.fury.io/py/hecstac)
+[![Docker Scout](https://github.com/fema-ffrd/hecstac/actions/workflows/docker-scout.yaml/badge.svg)](https://github.com/fema-ffrd/hecstac/actions/workflows/docker-scout.yaml)
 
 Utilities for creating STAC items from HEC models
 


### PR DESCRIPTION
Same fix as stormlit #92 so docker scout runs on the image built from the PR instead of "latest"