### PR TITLE
remove version existence check from main-push workflow

### DIFF
--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -39,10 +39,3 @@ jobs:
       version: ${{ needs.get-version.outputs.version }}
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-
-  github-release:
-    name: Create GitHub Release
-    needs: [python-build, pypi-publish, get-version, check-version-exists]
-    uses: ./.github/workflows/github-release.yaml
-    with:
-      version: ${{ needs.get-version.outputs.version }}

--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -20,20 +20,6 @@ jobs:
   get-version:
     name: Extract Package Version
     uses: ./.github/workflows/get-version.yaml
-    
-  check-version-exists:
-    name: Verify Version is New
-    needs: get-version
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fail if version already exists
-        if: needs.get-version.outputs.is_new_version != 'true'
-        run: |
-          echo "::error::ERROR: Version ${{ needs.get-version.outputs.version }} already exists as a tag."
-          echo "::error::Please update the version in hecstac/version.py before releasing to main."
-          exit 1
-      - name: Version check passed
-        run: echo "Version ${{ needs.get-version.outputs.version }} is new. Proceeding with release."
 
   docker-build-push:
     name: Build and Push Docker Image

--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -16,10 +16,14 @@ jobs:
     uses: ./.github/workflows/python-build.yaml
     with:
       run_tests: false
+      
+  get-version:
+    name: Extract Package Version
+    uses: ./.github/workflows/get-version.yaml
 
   docker-build-push:
     name: Build and Push Docker Image
-    needs: [python-build]
+    needs: [python-build, get-version]
     uses: ./.github/workflows/docker-build.yaml
     with:
       push_to_registry: true
@@ -29,7 +33,7 @@ jobs:
 
   pypi-publish:
     name: Publish to PyPI
-    needs: [python-build]
+    needs: [python-build, get-version]
     uses: ./.github/workflows/pypi-publish.yaml
     with:
       version: ${{ needs.get-version.outputs.version }}

--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -16,14 +16,10 @@ jobs:
     uses: ./.github/workflows/python-build.yaml
     with:
       run_tests: false
-      
-  get-version:
-    name: Extract Package Version
-    uses: ./.github/workflows/get-version.yaml
 
   docker-build-push:
     name: Build and Push Docker Image
-    needs: [python-build, get-version, check-version-exists]
+    needs: [python-build]
     uses: ./.github/workflows/docker-build.yaml
     with:
       push_to_registry: true
@@ -33,7 +29,7 @@ jobs:
 
   pypi-publish:
     name: Publish to PyPI
-    needs: [python-build, get-version, check-version-exists]
+    needs: [python-build]
     uses: ./.github/workflows/pypi-publish.yaml
     with:
       version: ${{ needs.get-version.outputs.version }}


### PR DESCRIPTION
This was leftover from the old "publish on push to main" workflow and is no longer needed since we only release when tags are manually created.